### PR TITLE
docs: add callable.md to the nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - MuFidelity: api/mu_fidelity.md
       - AverageStability: api/avg_stability.md
   - Contributing: contributing.md
+  - Callable: callable.md
 
 theme:
   name: "material"


### PR DESCRIPTION
Fix a missing error when adding the `callable.md` it was not added to the nav property of `mkdocs.yml`