### PR TITLE
minor: Causal fidelity metrics: Harmonization between timeseries and image - detailed evaluate

### DIFF
--- a/docs/api/deletion.md
+++ b/docs/api/deletion.md
@@ -10,7 +10,29 @@ the important pixels.
     
     -- <cite>[RISE: Randomized Input Sampling for Explanation of Black-box Models (2018)](https://arxiv.org/abs/1806.07421)</cite>[^1]
 
-The better the method, the smaller the score.
+
+## Score interpretation
+
+If explanations are accurate, the score will quickly fall from the score on non-perturbed input to the score of a random predictor.
+  Thus, in this case, a lower score represent a more accurate explanation.
+
+
+## Remarks
+
+This metric only evaluate the order of importance between features.
+
+The parameters metric, steps and max_percentage_perturbed may drastically change the score :
+
+- For inputs with many features, increasing the number of steps will allow you to capture more efficiently the difference between attributions methods.
+
+- The order of importance of features with low importance may not matter, hence, decreasing the max_percentage_perturbed,
+may make the score more relevant.
+  
+Sometimes, attributions methods also returns negative attributions,
+for those methods, do not take the absolute value before computing insertion and deletion metrics.
+Otherwise, negative attributions may have higher absolute values, and the order of importance between features will change.
+Therefore, take those previous remarks into account to get a relevant score.
+
 
 ## Example
 

--- a/docs/api/deletion_ts.md
+++ b/docs/api/deletion_ts.md
@@ -6,7 +6,35 @@ This metric computes the capacity of the model to make predictions while perturb
 Specific explanation metrics for time series are necessary because time series and images have different shapes (number of dimensions) and perturbations should be applied differently to them.
 As the insertion and deletion metrics use input perturbation to be computed, creating new metrics for time series is natural[^2].
 
-The better the method, the smaller the score.
+
+## Score interpretation
+
+The interpretation of the score depends on the score metric you are using to evaluate your model.
+- For metrics where the score increases with the performance of the model (such as accuracy).
+If explanations are accurate, the score will quickly fall from the score on non-perturbed input to the score of a random predictor.
+  Thus, in this case, a lower score represent a more accurate explanation.
+  
+- For metrics where the score decreases with the performance of the model (such as losses). 
+If explanations are accurate, the score will quickly rise.
+  Thus, in this case, a higher score represent a more accurate explanation.
+
+
+## Remarks
+
+This metric only evaluate the order of importance between features.
+
+The parameters metric, steps and max_percentage_perturbed may drastically change the score :
+
+- For inputs with many features, increasing the number of steps will allow you to capture more efficiently the difference between attributions methods.
+
+- The order of importance of features with low importance may not matter, hence, decreasing the max_percentage_perturbed,
+may make the score more relevant.
+  
+Sometimes, attributions methods also returns negative attributions,
+for those methods, do not take the absolute value before computing insertion and deletion metrics.
+Otherwise, negative attributions may have higher absolute values, and the order of importance between features will change.
+Therefore, take those previous remarks into account to get a relevant score.
+
 
 ## Example
 
@@ -25,5 +53,5 @@ score = metric.evaluate(explanations)
 
 {{xplique.metrics.DeletionTS}}
 
-[^1]: [RISE: Randomized Input Sampling for Explanation of Black-box Models (2018)](https://arxiv.org/abs/1806.07421)
-[^2]: [Towards a Rigorous Evaluation of XAI Methods on Time Series (2019)](https://arxiv.org/abs/1909.07082)
+[^1]:[RISE: Randomized Input Sampling for Explanation of Black-box Models (2018)](https://arxiv.org/abs/1806.07421)
+[^2]:[Towards a Rigorous Evaluation of XAI Methods on Time Series (2019)](https://arxiv.org/abs/1909.07082)

--- a/docs/api/insertion.md
+++ b/docs/api/insertion.md
@@ -10,7 +10,29 @@ The Insertion Fidelity metric measures how well a saliency-map–based explanati
     
     -- <cite>[RISE: Randomized Input Sampling for Explanation of Black-box Models (2018)](https://arxiv.org/abs/1806.07421)</cite>[^1]
 
-The better the method, the higher the score.
+
+## Score interpretation
+
+If explanations are accurate, the score will quickly rise to the score on non-perturbed input.
+  Thus, in this case, a higher score represent a more accurate explanation.
+
+
+## Remarks
+
+This metric only evaluate the order of importance between features.
+
+The parameters metric, steps and max_percentage_perturbed may drastically change the score :
+
+- For inputs with many features, increasing the number of steps will allow you to capture more efficiently the difference between attributions methods.
+
+- The order of importance of features with low importance may not matter, hence, decreasing the max_percentage_perturbed,
+may make the score more relevant.
+  
+Sometimes, attributions methods also returns negative attributions,
+for those methods, do not take the absolute value before computing insertion and deletion metrics.
+Otherwise, negative attributions may have higher absolute values, and the order of importance between features will change.
+Therefore, take those previous remarks into account to get a relevant score.
+
 
 ## Example
 

--- a/docs/api/insertion_ts.md
+++ b/docs/api/insertion_ts.md
@@ -3,7 +3,35 @@
 The Time Series Insertion Fidelity metric measures the faithfulness of explanations on Time Series predictions[^2].
 This metric computes the capacity of the model to make predictions while only the most important features are not perturbed[^1].
 
-The better the method, the higher the score.
+
+## Score interpretation
+
+The interpretation of the score depends on the score metric you are using to evaluate your model.
+- For metrics where the score increases with the performance of the model (such as accuracy).
+If explanations are accurate, the score will quickly rise to the score on non-perturbed input.
+  Thus, in this case, a higher score represent a more accurate explanation.
+  
+- For metrics where the score decreases with the performance of the model (such as losses). 
+If explanations are accurate, the score will quickly fall to the score on non-perturbed input.
+  Thus, in this case, a lower score represent a more accurate explanation.
+
+
+## Remarks
+
+This metric only evaluate the order of importance between features.
+
+The parameters metric, steps and max_percentage_perturbed may drastically change the score :
+
+- For inputs with many features, increasing the number of steps will allow you to capture more efficiently the difference between attributions methods.
+
+- The order of importance of features with low importance may not matter, hence, decreasing the max_percentage_perturbed,
+may make the score more relevant.
+  
+Sometimes, attributions methods also returns negative attributions,
+for those methods, do not take the absolute value before computing insertion and deletion metrics.
+Otherwise, negative attributions may have higher absolute values, and the order of importance between features will change.
+Therefore, take those previous remarks into account to get a relevant score.
+
 
 ## Example
 

--- a/tests/metrics/test_fidelity.py
+++ b/tests/metrics/test_fidelity.py
@@ -4,6 +4,7 @@ import numpy as np
 from ..utils import generate_model, generate_timeseries_model, generate_data, almost_equal
 from xplique.metrics import Insertion, Deletion, MuFidelity, InsertionTS, DeletionTS
 
+
 def test_mu_fidelity():
     # ensure we can compute the metric with consistents arguments
     input_shape, nb_labels, nb_samples = ((32, 32, 3), 10, 20)
@@ -50,20 +51,23 @@ def test_perturbation_metrics():
     model = generate_timeseries_model(input_shape, nb_labels)
     explanations = np.random.uniform(0, 1, x.shape)
 
-    for step in [-1, 2, 10]:
-        for max_percentage_perturbed in [0.2, 1.0]:
-            for baseline_mode in [0.0, "zero", "inverse", "negative"]:
+    for step in [-1, 10]:
+        for baseline_mode in [0.0, "inverse"]:
+            for metric in ["loss", "accuracy"]:
                 score_insertion = InsertionTS(
-                    model, x, y, metric="loss", baseline_mode=baseline_mode,
-                    steps=step, max_percentage_perturbed=max_percentage_perturbed,
+                    model, x, y, metric=metric, baseline_mode=baseline_mode,
+                    steps=step, max_percentage_perturbed=0.2,
                 )(explanations)
                 score_deletion = DeletionTS(
-                    model, x, y, metric="loss", baseline_mode=baseline_mode,
-                    steps=step, max_percentage_perturbed=max_percentage_perturbed,
+                    model, x, y, metric=metric, baseline_mode=baseline_mode,
+                    steps=step, max_percentage_perturbed=0.2,
                 )(explanations)
 
                 for score in [score_insertion, score_deletion]:
-                    assert 0.0 < score < 1
+                    if metric == "loss":
+                        assert 0.0 < score
+                    elif score == "accuracy":
+                        assert 0.0 <= score <= 1.0
 
 
 def test_perfect_correlation():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,8 @@ def generate_timeseries_model(input_shape=(20, 10), output_shape=10):
     model.add(GlobalAveragePooling1D())
     model.add(Dense(output_shape))
     model.add(Activation('softmax'))
-    model.compile(loss='categorical_crossentropy', optimizer='sgd')
+    model.compile(loss='categorical_crossentropy', optimizer='sgd',
+                  metrics=['accuracy'])
 
     return model
 

--- a/xplique/plots/tabular.py
+++ b/xplique/plots/tabular.py
@@ -13,9 +13,9 @@ def _sanitize_features_name(explanations, features_name):
     if features_name is None:
         single_explanation = len(explanations.shape)==1
         if single_explanation:
-            features_name = ["Feature %s"%(j) for j in range(len(explanations))]
+            features_name = [f"Feature {str(j)}" for j in range(len(explanations))]
         else:
-            features_name = ["Feature %s"%(j) for j in range(explanations.shape[1])]
+            features_name = [f"Feature {str(j)}" for j in range(explanations.shape[1])]
     return features_name
 
 def _select_features(explanations, max_display, features_name):
@@ -151,7 +151,9 @@ def plot_feature_impact(
         if features_value is None:
             yticklabels.append(features_name[idx_kept])
         else:
-            yticklabels.append("%0.03f"%(features_value[idx_kept]) +" = "+ features_name[idx_kept])
+            yticklabels.append(
+                f"{str(round(features_value[idx_kept], 3))} = {features_name[idx_kept]}"
+            )
 
     y_pos = np.arange(num_features_kept)  # the label locations
 
@@ -180,7 +182,7 @@ def plot_feature_impact(
             axes.text(
                 explanation_kept[i] - 0.02*xscale,
                 y_pos[i],
-                str("%0.02f"%explanation_kept[i]),
+                f"{str(round(explanation_kept[i], 2))}",
                 horizontalalignment='right',
                 verticalalignment='center',
                 fontsize=10
@@ -189,7 +191,7 @@ def plot_feature_impact(
             axes.text(
                 explanation_kept[i] + 0.02*xscale,
                 y_pos[i],
-                str("%0.02f"%explanation_kept[i]),
+                f"{str(round(explanation_kept[i], 2))}",
                 horizontalalignment='left',
                 verticalalignment='center',
                 fontsize=10


### PR DESCRIPTION
# minor: Causal fidelity metrics: Harmonization between timeseries and image - detailed evaluate


This pull request is divided in 3 contributions :

- Harmonization between:
  - CausalFidelity and CausalFidelityTS edcb5c4
  - Adapt testing to harmonization 03d3849
- Detailed evaluate for:
  - CausalFidelity e059af8
  - CausalFidelityTS 4351630
- Remarks in the docs for some metrics: 
  - Insertion and Deletion 4e177cc
  - InsertionTS and DeletionTS af217c7

and a correction for the new version of pylint to work: 22aebd4 (we should use f-string).

### Harmonization

The previously developed causal fidelity metrics for timeseries had several differences in their behavior compared to the initial Insertion and Deletion, thus an harmonization was necessary.

### Detailed evaluate

Furthermore, through discussion, the necessity of accessing all values computed for insertion and deletion was necessary. The idea thus was to add a method (detailed_evaluate) with returns a dictionnary of such values. This method will then be called by the initial evaluate method that will return the auc.

The output of the detailed evaluate method can be used to draw score evolution curves, where the score depend on the number of features perturbed.

### Interpretation and remarks in the documentation

There are remarks about:

- The score interpretation
- How max_percentage_perturbed can influence the score
- The fact that evaluating Insertion and Deletion on the absolute value of explanations may not provide relevant scores.