### PR TITLE
AverageStability metric: ensure noisy masks applied use radius parameter

### DIFF
--- a/tests/metrics/test_stability.py
+++ b/tests/metrics/test_stability.py
@@ -26,6 +26,22 @@ def test_average_stability():
             assert score < np.prod(x.shape[:-1])
 
 
+def test_noise_radius():
+    # ensure the noise added correspond to the radius passed.
+    input_shape, nb_labels, nb_samples = ((32, 32, 3), 10, 20)
+    x, y = generate_data(input_shape, nb_labels, nb_samples)
+    model = generate_model(input_shape, nb_labels)
+
+    mean_noise = []
+
+    for radius in [1.0 * 10**i for i in range(-4, 4)]:
+        metric = AverageStability(model, x, y, radius=radius, nb_samples=1000)
+        mean_noise.append(np.mean(metric.noisy_masks))
+
+    # the list should striclty increase
+    assert all(i < j for i, j in zip(mean_noise, mean_noise[1:]))
+
+
 def test_perfect_stability():
     """Ensure we get perfect stability when explanation is the same"""
     input_shape, nb_labels, nb_samples = ((8, 8, 1), 2, 20)

--- a/xplique/metrics/stability.py
+++ b/xplique/metrics/stability.py
@@ -30,7 +30,8 @@ class AverageStability(ExplainerMetric):
     batch_size
         Number of samples to explain at once, if None compute all at once.
     radius
-        Radius defining the neighborhood of the inputs with respect to l1 distance.
+        Maximum value of the uniform noise added to the inputs before recalculating their
+        explanations.
     distance
         Distance metric between the explanations.
     nb_samples
@@ -60,8 +61,8 @@ class AverageStability(ExplainerMetric):
             raise ValueError(f"{distance} is not a valid distance.")
 
         # prepare the noisy masks that will be used to generate the neighbors
-        nb_variables = np.prod(inputs.shape[1:])
-        self.noisy_masks = tf.random.uniform((nb_samples, *inputs.shape[1:]), 0, 1.0 / nb_variables)
+        self.noisy_masks = tf.random.uniform((nb_samples, *inputs.shape[1:]), 0,
+                                             self.radius)
 
     def evaluate(self,
                  explainer: Callable,


### PR DESCRIPTION
@DavidPetiteau and David V.  identified a problem in the stability metric `AverageStability` : the radius is fixed and the parameter is not used. This RP fixes this problem and introduces a test to avoid this in the future.

