### PR TITLE
Add plots for metrics and timeseries

### DIFF
--- a/tests/plots/test_metric_plots.py
+++ b/tests/plots/test_metric_plots.py
@@ -1,0 +1,56 @@
+import matplotlib
+import numpy as np
+import os
+
+from xplique.plots.metrics import barplot, fidelity_curves
+
+
+def test_bar_plot():
+    # test metrics barplot
+    cmap = matplotlib.cm.get_cmap("Set3")
+    methods_colors = {"method_" + str(i): cmap(i / 9) for i in range(10)}
+
+    scores = {}
+    for metric in ["metric_1", "metric_2"]:
+        scores[metric] = {
+            "method_" + str(i): np.random.random_sample()
+            for i in range(10)
+        }
+
+    filepath = "tests/plots/barplot_test.png"
+    barplot(
+        scores,
+        sort_metric="metric_1",
+        ascending=True,
+        title="test bar-plot",
+        filepath=filepath,
+        methods_colors=methods_colors
+    )
+
+    assert os.path.exists(filepath)
+    os.remove(filepath)
+
+
+def test_curves():
+    # test fidelity metric curves plot
+    cmap = matplotlib.cm.get_cmap("Set3")
+    methods_colors = {"method_" + str(i): cmap(i / 9) for i in range(10)}
+
+    steps = np.linspace(0, 100, num=11)
+    detailed_scores = {
+        "method_" + str(i):
+            {step: val for (step, val) in
+             zip(steps, np.linspace(*np.random.randint(0, 100, 2), num=11))}
+        for i in range(10)
+    }
+
+    filepath = "tests/plots/fidelity_curves_test.png"
+    fidelity_curves(
+        detailed_scores,
+        title="test curves",
+        filepath=filepath,
+        methods_colors=methods_colors
+    )
+
+    assert os.path.exists(filepath)
+    os.remove(filepath)

--- a/tests/plots/test_timeseries_plots.py
+++ b/tests/plots/test_timeseries_plots.py
@@ -1,0 +1,57 @@
+import matplotlib
+import numpy as np
+import os
+
+from xplique.plots.timeseries import plot_attributions
+
+
+def test_one_explanation():
+    # test timeseries plot attribution method with one explanation
+    nb_features = 7
+    nb_time_steps = 26
+    title = "test one explanation"
+    filepath = "tests/plots/timeseries_one_attribution_test.png"
+    cmap = "coolwarm"
+
+    features = ["feature_" + str(i) for i in range(nb_features)]
+    explanations = np.random.uniform(size=(nb_features, nb_time_steps))
+
+    plot_attributions(
+        explanations,
+        features,
+        title,
+        filepath,
+        cmap=cmap,
+        colorbar=True,
+    )
+
+    assert os.path.exists(filepath)
+    os.remove(filepath)
+
+
+def test_several_explanations():
+    # test timeseries plot attribution method with several explanations
+    nb_features = 7
+    nb_time_steps = 26
+    title = "test one explanation"
+    filepath = "tests/plots/timeseries_several_attributions_test.png"
+    cmap = "coolwarm"
+
+    features = ["feature_" + str(i) for i in range(nb_features)]
+    explanations = {
+        "method_" + str(i):
+            np.random.uniform(size=(nb_features, nb_time_steps))
+        for i in range(10)
+    }
+
+    plot_attributions(
+        explanations,
+        features,
+        title,
+        filepath,
+        cmap=cmap,
+        colorbar=True,
+    )
+
+    assert os.path.exists(filepath)
+    os.remove(filepath)

--- a/xplique/plots/metrics.py
+++ b/xplique/plots/metrics.py
@@ -1,0 +1,164 @@
+"""
+Plots for metric
+"""
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+from ..types import Optional, Union, Dict, Any
+
+
+def barplot(
+        scores: Dict[str, Dict[str, float]],
+        sort_metric: str = None,
+        ascending: bool = False,
+        title: str = "",
+        filepath: str = None,
+        methods_colors: Optional[Union[Dict[str, Any], str]] = None
+):
+    """
+    Make a bar chart gathering the score of each method for the different metrics used.
+
+    Parameters
+    ----------
+    scores
+        Dictionary of dictionary, with metrics scores,
+        1st dict: the keys are the metric names and the values are dictionaries,
+        2nd dict: the keys are the method names
+        and the values the corresponding method-metric score.
+    sort_metric
+        Name of the metric used to sort the methods (a key of the directory).
+    ascending
+        Specify the sorting direction (need a sort_metric specified).
+    title
+        Title of the graphic.
+    filepath
+        Path the file will be saved at. If None, the function will call plt.show().
+    methods_colors
+        Either a dictionary of colors (key are method name, value are matplotlib
+        supported color) or string of a matplotlib cmap (e.g 'Set3', 'jet'...).
+    """
+    # pylint: disable=invalid-name
+
+    metrics = list(scores.keys())
+    # sort values
+    if sort_metric is not None:
+        methods = [
+            k for k, _ in
+            sorted(scores[sort_metric].items(), key=lambda item: item[1], reverse=not ascending)
+        ]
+    else:
+        # get methods from a metric (order do not import)
+        methods = list(scores[list(scores.keys())[0]])
+
+    # set x abscissa for each metric
+    metrics_x = {metrics[i]: i for i in range(len(metrics))}
+
+    # set x delta for each method
+    width = (1 - 0.2) / len(methods)
+    # -0.4 to get 0.2 between each metric, 0.5 width to center the bars
+    methods_d = {methods[i]: -0.4 + (i + 0.5) * width for i in range(len(methods))}
+
+    # set methods colors
+    if not isinstance(methods_colors, dict):
+        # either None or string
+        if methods_colors is None:
+            # default cmap
+            cmap = matplotlib.cm.get_cmap("Set3")
+        else:
+            # methods_color is a string linking to a cmap
+            cmap = matplotlib.cm.get_cmap(methods_colors)
+
+        methods_colors = {methods[i]: cmap(i / (len(methods) - 1))
+                          for i in range(len(methods))}
+
+    _, ax = plt.subplots(figsize=(4 + 2 * len(metrics), 4))
+    handles = {}
+    for metric in metrics:
+        for method in methods:
+            handles[method] = ax.bar(
+                metrics_x[metric] + methods_d[method],
+                scores[metric][method],
+                color=methods_colors[method],
+                align="center",
+                width=width
+            )
+
+    ax.set_title(title)
+    plt.legend(handles.values(), methods, title="attribution methods", bbox_to_anchor=(1.05, 1))
+    ax.set_xlabel("metrics")
+    ax.set_ylabel("score")
+    plt.xticks(list(range(0, len(metrics))))
+    ax.set_xticklabels(metrics)
+    plt.xticks(rotation=0)
+    plt.tight_layout()
+
+    if filepath is not None:
+        plt.savefig(filepath)
+    else:
+        plt.show()
+
+
+def fidelity_curves(
+        detailed_scores: Dict[str, np.ndarray],
+        title: str = "",
+        filepath: Optional[str] = None,
+        methods_colors: Optional[Union[Dict[str, Any], str]] = None
+):
+    """
+    Plot the evolution curves for Insertion and Deletion metrics
+    based on their detailed_evaluate() method.
+    Plot the evolution of a model score depending on the number features perturbed
+
+    Parameters
+    ----------
+    detailed_scores
+        Dictionary of methods detailed scores.
+        The keys are the methods names.
+        The values are the output of the detailed_evaluate() from Insertion and Deletion.
+        (Please refer to this method for further details).
+    title
+        Title of the graphic.
+    filepath
+        Path the file will be saved at. If None, the function will call plt.show().
+    methods_colors
+        Either a dictionary of colors (key are method name, value are matplotlib
+        supported color) or string of a matplotlib cmap (e.g 'Set3', 'jet'...).
+    """
+    # pylint: disable=invalid-name
+
+    methods = list(detailed_scores.keys())
+
+    # set methods colors
+    if not isinstance(methods_colors, dict):
+        # either None or string
+        if methods_colors is None:
+            # default cmap
+            cmap = matplotlib.cm.get_cmap("Set3")
+        else:
+            # methods_color is a string linking to a cmap
+            cmap = matplotlib.cm.get_cmap(methods_colors)
+
+        methods_colors = {methods[i]: cmap(i / (len(methods) - 1))
+                          for i in range(len(methods))}
+
+    _, ax = plt.subplots(figsize=(10, 5))
+    for method, method_scores in detailed_scores.items():
+        ax.plot(
+            method_scores.keys(),
+            method_scores.values(),
+            label=method,
+            color=methods_colors[method],
+            linewidth=2.0,
+        )
+    ax.set_title(title)
+    ax.legend(title="attribution methods", bbox_to_anchor=(1.05, 1))
+    ax.set_xlabel("number of features perturbed")
+    ax.set_ylabel("score")
+    plt.tight_layout()
+
+    if filepath is not None:
+        plt.savefig(filepath)
+    else:
+        plt.show()

--- a/xplique/plots/timeseries.py
+++ b/xplique/plots/timeseries.py
@@ -1,0 +1,163 @@
+"""
+Pretty plots option for explanations
+"""
+
+import matplotlib
+from matplotlib import pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+from ..types import Union, Dict, List, Any
+
+
+def _arrange_subplots(
+        explanations: Dict[str, Union[np.array, tf.Tensor]],
+) -> Dict[str, Any]:
+    """
+    Determine how to arrange subplots so that the final output have coherent proportions.
+
+    Parameters
+    ----------
+    explanations
+        dictionary of explanations
+
+    Returns
+    -------
+    subplot_kwargs
+        Dictionary of arguments for the plt.subplots() method.
+
+    """
+    # initialize sizes and shapes
+    nb_subplots = len(explanations)
+    expl_shape = list(explanations.values())[0].shape
+    # matplotlib dimension are flipped compare to usual numpy of pandas
+    get_size = lambda x, y: (int(y * (1 + expl_shape[1] / 5)), int(x * (1 + expl_shape[0] / 5)))
+
+    found_arrange = False
+    # iterate to found arrangement
+    while not found_arrange:
+        for i in range(1, nb_subplots + 1):
+            if nb_subplots % i == 0:
+                plot_size = get_size(i, nb_subplots / i)
+                if plot_size[1] <= plot_size[0] <= 2 * plot_size[1]:
+                    found_arrange = True
+                    nrows = i
+                    ncols = int(nb_subplots / i)
+                    break
+        nb_subplots += 1
+    return {"nrows": nrows, "ncols": ncols, "figsize": plot_size}
+
+
+def _show_heatmap(
+        axe: matplotlib.axes.Axes,
+        explanations: Union[np.array, tf.Tensor],
+        features: List[str],
+        title: str = "",
+        cmap: str = "coolwarm",
+        **plot_kwargs
+) -> matplotlib.image.AxesImage:
+    """
+    Display a heatmap representing the attributions for timeseries.
+
+    Parameters
+    ----------
+    explanations
+        Attributions, they are numpy arrays or tensorflow tensors.
+        (With features * timesteps format).
+    features
+        List of features names, should match the first dimension of explanations
+    title
+        Title of the plot.
+    cmap
+        Matplotlib color map to apply.
+    plot_kwargs
+        Additional parameters passed to `plt.imshow()`.
+
+    Returns
+    -------
+    image
+        output of ax.imshow().
+    """
+    image = axe .imshow(explanations, cmap=cmap, **plot_kwargs)
+
+    axe .set_title(title, fontsize=12)
+
+    axe .set_xlabel("time-steps", fontsize=10)
+    time_steps = list(range(-explanations.shape[1], 0))
+    axe .set_xticks(np.arange(len(time_steps)))
+    axe .set_xticklabels(time_steps, fontsize=5)
+
+    axe .set_ylabel("features", fontsize=10)
+    axe .set_yticks(np.arange(len(features)))
+    axe .set_yticklabels(features, fontsize=8)
+
+    return image
+
+
+def plot_attributions(
+        explanations: Union[Dict[str, Union[np.array, tf.Tensor]], np.array, tf.Tensor],
+        features: List[str],
+        title: str = "",
+        filepath: str = None,
+        cmap: str = "coolwarm",
+        colorbar: bool = False,
+        **plot_kwargs,
+):
+    """
+    Display a heatmap representing the attributions for timeseries,
+    if it is called with a dictionary of explanations,
+    it will make subplots and show an heatmap for all elements of the dictionary.
+
+    Parameters
+    ----------
+    explanations
+        Can either be a dictionary of explanations or one explanation.
+        The explanations are numpy arrays or tensorflow tensors. (With features * timesteps format).
+    features
+        List of features names, should match the first dimension of explanations
+    title
+        Title of the plot.
+    filepath
+        Path the file will be saved at.
+        If None, the function will call plt.show()
+    cmap
+        Matplotlib color map to apply.
+    colorbar
+        If the color bar should be shown.
+    plot_kwargs
+        Additional parameters passed to `plt.imshow()`.
+    """
+    if isinstance(explanations, dict):
+        # find the right arrangement
+        subplot_kwargs = _arrange_subplots(explanations)
+        nrows = subplot_kwargs["nrows"]
+        fig, axes = plt.subplots(**subplot_kwargs)
+
+        # plot multiple heatmaps
+        for i, (method, explanation) in enumerate(explanations.items()):
+            image = _show_heatmap(
+                axes[i % nrows, i//nrows],
+                explanation,
+                features,
+                title=method,
+                cmap=cmap,
+                **plot_kwargs
+            )
+        fig.suptitle(title, fontsize=16)
+        plt.subplots_adjust(wspace=0.4)
+        if colorbar:
+            fig.colorbar(image, ax=axes.ravel().tolist())
+    else:
+        # plot a single heatmap
+        fig, axe = plt.subplots(
+            figsize=(1 + explanations.shape[1] / 5, 1 + explanations.shape[0] / 5)
+        )
+        image = _show_heatmap(axe, explanations, features, title=title, cmap=cmap, **plot_kwargs)
+        if colorbar:
+            fig.colorbar(image, ax=axe)
+        fig.tight_layout()
+
+    if filepath is not None:
+        plt.savefig(filepath)
+    else:
+        plt.show()


### PR DESCRIPTION
# Plots for metrics and timeseries

For metrics, the plots are added in 996fad3 and tested in d755524.
For timeseries, the plots are added in 70ded0d and tested in be8ff60.


## Metrics
Those are two plots that I often use. I though they may need to be integrated in Xplique.

I also made is so that each method can be assign a color and match between both plots.

### Metrics histograms
This one to compare the attribution methods through several metrics:
![barplot_test](https://user-images.githubusercontent.com/90199266/149510962-1c6a0799-3d66-4ba5-9636-dddaf5b79d10.png)

### Fidelity curves
This plot show the evolution of the score depending on the number of features perturbed. It is also used to compare methods. It can easily be done thank to the `detailed_evaluate()` method of `CausalFidelity` and `CausalFidelity` introduced in [pull request #70](https://github.com/deel-ai/xplique/pull/70).

Note that the lines on this plot are just here for testing the function.
![fidelity_curves_test](https://user-images.githubusercontent.com/90199266/149511271-b3f2545a-010d-4694-9789-b92339efc5d9.png)

## Timeseries
The following plots come from the same function, they both output heatmaps. But for the first, a numpy array is given while the second receives a dictionary of numpy arrays.

### One explanation heatmap
![timeseries_one_attribution_test](https://user-images.githubusercontent.com/90199266/152384151-5550021a-3f17-4ba4-a997-fc6439b2c846.png)

### Several explanations heatmaps
This plot should adapt the arrangement of the subplots based on the heatmap shape and their number.
![timeseries_several_attributions_test](https://user-images.githubusercontent.com/90199266/152384895-269f22d6-776e-4277-9813-14b64f4d8e48.png)
