### PR TITLE
Causal fidelity for tabular

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,8 +3,10 @@ disable=
     R0903, # allows to expose only one public method
     R0914, # allow multiples local variables
 
+    E0401, # pending issue with pylint see pylint#2603
+
     E1123, # issues between pylint and tensorflow since 2.2.0
-    E1120, # see https://github.com/PyCQA/pylint/issues/3613
+    E1120, # see pylint#3613
 
 [FORMAT]
 max-line-length=100

--- a/docs/api/deletion_tab.md
+++ b/docs/api/deletion_tab.md
@@ -1,0 +1,53 @@
+# DeletionTab
+
+The tabular data Deletion Fidelity metric measures the faithfulness of explanations on tabular data predictions.
+This metric computes the capacity of the model to make predictions while only the most important features are not perturbed[^1].
+
+
+## Score interpretation
+
+The interpretation of the score depends on the score metric you are using to evaluate your model.
+- For metrics where the score increases with the performance of the model (such as accuracy).
+If explanations are accurate, the score will quickly rise to the score on non-perturbed input.
+  Thus, in this case, a higher score represent a more accurate explanation.
+  
+- For metrics where the score decreases with the performance of the model (such as losses). 
+If explanations are accurate, the score will quickly fall to the score on non-perturbed input.
+  Thus, in this case, a lower score represent a more accurate explanation.
+
+
+## Remarks
+
+This metric only evaluate the order of importance between features.
+
+The parameters metric, steps and max_percentage_perturbed may drastically change the score :
+
+- For inputs with many features, increasing the number of steps will allow you to capture more efficiently the difference between attributions methods.
+
+- The order of importance of features with low importance may not matter, hence, decreasing the max_percentage_perturbed,
+may make the score more relevant.
+  
+Sometimes, attributions methods also returns negative attributions,
+for those methods, do not take the absolute value before computing deletion metrics.
+Otherwise, negative attributions may have higher absolute values, and the order of importance between features will change.
+Therefore, take those previous remarks into account to get a relevant score.
+
+
+## Example
+
+```python
+from xplique.metrics import DeletionTab
+from xplique.attributions import Saliency
+
+# load images, labels and model
+# ...
+explainer = Saliency(model)
+explanations = explainer(inputs, labels)
+
+metric = DeletionTab(model, inputs, labels)
+score = metric.evaluate(explanations)
+```
+
+{{xplique.metrics.DeletionTab}}
+
+[^1]:[RISE: Randomized Input Sampling for Explanation of Black-box Models (2018)](https://arxiv.org/abs/1806.07421)

--- a/docs/api/insertion_tab.md
+++ b/docs/api/insertion_tab.md
@@ -1,0 +1,53 @@
+# InsertionTab
+
+The tabular data Insertion Fidelity metric measures the faithfulness of explanations on tabular data predictions.
+This metric computes the capacity of the model to make predictions while only the most important features are not perturbed[^1].
+
+
+## Score interpretation
+
+The interpretation of the score depends on the score metric you are using to evaluate your model.
+- For metrics where the score increases with the performance of the model (such as accuracy).
+If explanations are accurate, the score will quickly rise to the score on non-perturbed input.
+  Thus, in this case, a higher score represent a more accurate explanation.
+  
+- For metrics where the score decreases with the performance of the model (such as losses). 
+If explanations are accurate, the score will quickly fall to the score on non-perturbed input.
+  Thus, in this case, a lower score represent a more accurate explanation.
+
+
+## Remarks
+
+This metric only evaluate the order of importance between features.
+
+The parameters metric, steps and max_percentage_perturbed may drastically change the score :
+
+- For inputs with many features, increasing the number of steps will allow you to capture more efficiently the difference between attributions methods.
+
+- The order of importance of features with low importance may not matter, hence, decreasing the max_percentage_perturbed,
+may make the score more relevant.
+  
+Sometimes, attributions methods also returns negative attributions,
+for those methods, do not take the absolute value before computing insertion metrics.
+Otherwise, negative attributions may have higher absolute values, and the order of importance between features will change.
+Therefore, take those previous remarks into account to get a relevant score.
+
+
+## Example
+
+```python
+from xplique.metrics import InsertionTab
+from xplique.attributions import Saliency
+
+# load images, labels and model
+# ...
+explainer = Saliency(model)
+explanations = explainer(inputs, labels)
+
+metric = InsertionTab(model, inputs, labels)
+score = metric.evaluate(explanations)
+```
+
+{{xplique.metrics.InsertionTab}}
+
+[^1]:[RISE: Randomized Input Sampling for Explanation of Black-box Models (2018)](https://arxiv.org/abs/1806.07421)

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,12 +179,14 @@ All the attributions method presented below handle both **Classification** and *
 \* : See the [Callable documentation](callable.md)
 
 | **Attribution Metrics** | Type of Model | Property         | Source                                                                                |
-| :---------------------- | :------------ | :--------------- | :------------------------------------------------------------------------------------ |
+|:------------------------| :------------ | :--------------- |:--------------------------------------------------------------------------------------|
 | MuFidelity              | TF            | Fidelity         | [Paper](https://arxiv.org/abs/2005.00631)                                             |
 | Deletion                | TF            | Fidelity         | [Paper](https://arxiv.org/abs/1806.07421)                                             |
 | Insertion               | TF            | Fidelity         | [Paper](https://arxiv.org/abs/1806.07421)                                             |
 | Deletion TS             | TF            | Fidelity         | [Paper1](https://arxiv.org/abs/1806.07421) [Paper2](https://arxiv.org/abs/1909.07082) |
 | Insertion TS            | TF            | Fidelity         | [Paper1](https://arxiv.org/abs/1806.07421) [Paper2](https://arxiv.org/abs/1909.07082) |
+| Deletion Tab            | TF            | Fidelity         | [Paper1](https://arxiv.org/abs/1806.07421) [Paper2](https://arxiv.org/abs/1909.07082) |
+| Insertion Tab           | TF            | Fidelity         | [Paper1](https://arxiv.org/abs/1806.07421) [Paper2](https://arxiv.org/abs/1909.07082) |
 | Average Stability       | TF            | Stability        | [Paper](https://arxiv.org/abs/2005.00631)                                             |
 | MeGe                    | TF            | Representativity | [Paper](https://arxiv.org/abs/2009.04521)                                             |
 | ReCo                    | TF            | Consistency      | [Paper](https://arxiv.org/abs/2009.04521)                                             |

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,8 +42,8 @@ def generate_regression_model(features_shape, output_shape=1):
     model.add(Dense(4, activation='relu'))
     model.add(Dense(4, activation='relu'))
     model.add(Dense(output_shape))
-    model.compile(loss='mean_absolute_error',
-                  optimizer='sgd')
+    model.compile(loss='mean_absolute_error', optimizer='sgd',
+                  metrics=['accuracy'])
 
     return model
 

--- a/xplique/metrics/__init__.py
+++ b/xplique/metrics/__init__.py
@@ -2,6 +2,7 @@
 Explanations Metrics module
 """
 
-from .fidelity import MuFidelity, Deletion, Insertion, DeletionTS, InsertionTS
+from .fidelity import MuFidelity, Deletion, Insertion, DeletionTS, InsertionTS, \
+    DeletionTab, InsertionTab
 from .stability import AverageStability
 from .representativity import MeGe

--- a/xplique/plots/tabular.py
+++ b/xplique/plots/tabular.py
@@ -199,10 +199,10 @@ def plot_feature_impact(
 
     # add some text for labels and custom y-axis tick labels
     axes.set_xlabel('Impact on output')
+    axes.set_ylabel('')
     axes.set_title('Features impact')
     axes.set_yticks(y_pos)
     axes.set_yticklabels(yticklabels)
-    axes.legend()
 
     # make the plot prettier
     fig.tight_layout()
@@ -293,6 +293,7 @@ def summary_plot_tabular(
 
     # build the figure
     row_height = 0.4
+    plt.figure()
     if plot_size is None:
         plt.gcf().set_size_inches(8, nb_features_kept * row_height + 1.5)
     elif isinstance(plot_size,(list, tuple)):


### PR DESCRIPTION
# Add causal fidelity metrics for tabular data

The subject of this pull request is to add causal fidelity metrics for tabular data (deletion and insertion):
- Add metrics 318a019
- Add docs 7809cd8
- Add unit tests 98f7245

# Other contribution

- Correct  xplique/plots/tabular.py to avoid warnings b193084

