### PR TITLE
Correct wrapper bug and add corresponding testing

### DIFF
--- a/tests/generic/test_wrapper.py
+++ b/tests/generic/test_wrapper.py
@@ -1,0 +1,82 @@
+"""
+Test for the wrapper
+Also serve as a generic test
+"""
+
+import numpy as np
+import tensorflow as tf
+
+from xplique.attributions import KernelShap, Lime, Occlusion
+from ..utils import generate_dataset, generate_linear_model, almost_equal
+
+
+def test_wrapper():
+    """
+    Test the wrapping of a sklearn model, by comparing it to a keras model.
+    Both are linear regression model with really close weights.
+    We expect the explanations on those models to be close as well.
+    """
+    nb_samples = 100
+    epsilon = 1.e-4 * nb_samples
+    dataset, _, features_coef = generate_dataset(nb_samples)
+
+    libraries = [
+        "sklearn",
+        "keras",
+    ]
+
+    models = {
+        lib: generate_linear_model(features_coef, lib)
+        for lib in libraries
+    }
+
+    # we want both models to be close enough
+    y_preds = [np.array(model(dataset)).reshape((nb_samples,)) for model in models.values()]
+    assert almost_equal(y_preds[0], y_preds[1], epsilon)
+
+    # Define explainers
+    model_explainers = {}
+    for library, model in models.items():
+        model_explainers[library] = {
+            "KernelShap": KernelShap(
+                model,
+                nb_samples=200,  # 2000
+                ref_value=0.0,
+                batch_size=nb_samples
+            ),
+            "Lime": Lime(
+                model,
+                nb_samples=2000,  # 2000
+                ref_value=0.0,
+                distance_mode="cosine",
+                kernel_width=1.0,
+                batch_size=nb_samples
+            ),
+            "Occlusion": Occlusion(
+                model,
+                patch_size=1,
+                patch_stride=1,
+                occlusion_value=0.0,
+                batch_size=nb_samples
+            ),
+        }
+
+    # cast a subset to tf format
+    inputs_tf = tf.cast(dataset, tf.float32)
+    targets_tf = tf.ones((len(dataset), 1))
+
+    explanations = {}
+
+    # compute explanations for all methods
+    for library, explainers in model_explainers.items():
+        explanations[library] = {}
+        for method, explainer in explainers.items():
+            # Lime is not stable compared, a seed is needed
+            tf.random.set_seed(0)
+            # compute explanation for a given method
+            explanations[library][method] = explainer(inputs_tf, targets_tf)
+
+    for method in explanations[libraries[0]].keys():
+        expl0 = explanations[libraries[0]][method]
+        expl1 = explanations[libraries[1]][method]
+        assert almost_equal(expl0, expl1, epsilon)

--- a/xplique/commons/callable_operations.py
+++ b/xplique/commons/callable_operations.py
@@ -44,6 +44,13 @@ def predictions_one_hot_callable(
     else:
         pred = model(inputs.numpy())
 
+    # make sure that the prediction shape is coherent
+    if inputs.shape[0] != 1:
+        # a batch of prediction is required
+        if len(pred.shape) == 1:
+            # The prediction dimension disappeared
+            pred = tf.expand_dims(pred, axis=1)
+
     pred = tf.cast(pred, dtype=tf.float32)
     scores = tf.reduce_sum(pred * targets, axis=-1)
 


### PR DESCRIPTION
# Wrapper bug correction and first generic testing

This pull request can be divided in two parts:
- Resolve #93 5499b91
- A new generic testing for the wrapper cecc89f


### The bug correction

The bug reported and described in #93 was corrected as suggested. In `xplique.common.callable_operations.predictions_ont_hot_callable()` a test is effectuated to verify if the target dimension disappeared in the prediction.


### The new test

The issue #93 was created with a minimal example of the bug, however the bug is now fixed. Nevertheless, I figured that I could use this code to build a test for the wrapper and a first generic test.

The test process is the following : 
- A dataset where the output is a linear combinaison of the inputs is created (some inputs are not used and noise is added).
- Two linear regression models are created and trained on the dataset. One with Keras and one with sklearn (Wrapped afterward).
- We verify that the prediction of both models are close (thus weights are close).
- Then we compare method by method that the explanations on both models are close.

Note that only Lime, KernelShap and Occlusion are tested as they are the only method applicable to the LinearRegression model from the Scikit-Learn library.
