### PR TITLE
object detector: fix empty output case

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,11 +2,10 @@
 disable=
     R0903, # allows to expose only one public method
     R0914, # allow multiples local variables
-
     E0401, # pending issue with pylint see pylint#2603
-
     E1123, # issues between pylint and tensorflow since 2.2.0
     E1120, # see pylint#3613
+    C3001, # lambda function as variable
 
 [FORMAT]
 max-line-length=100

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="Xplique",
-    version="0.3.1",
+    version="0.4.0",
     description="Explanations toolbox for Tensorflow 2",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/xplique/__init__.py
+++ b/xplique/__init__.py
@@ -6,7 +6,7 @@ The goal of Xplique is to provide a simple interface to the latest explanation
 techniques
 """
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 from . import attributions
 from . import concepts

--- a/xplique/attributions/object_detector.py
+++ b/xplique/attributions/object_detector.py
@@ -189,7 +189,7 @@ class ImageObjectDetectorScoreCalculator:
         objects = model(inp)
         score_values = []
         for obj, obj_ref in zip(objects, object_ref):
-            if obj is None:
+            if obj is None or obj.shape[0] == 0:
                 score_values.append(tf.constant(0.0, dtype=inp.dtype))
             else:
                 current_boxes, proba_detection, classification = \


### PR DESCRIPTION
This PR concerns a bug in the Attribution module.

As reported by @dejeanph, when an empty output is received from a bbox model, we should catch it and don't iterate over it. This edge case is now handled correctly.

