### PR TITLE
Resolved `len is not well-defined for symbolic tensors`

### DIFF
--- a/xplique/attributions/lime.py
+++ b/xplique/attributions/lime.py
@@ -400,7 +400,7 @@ class Lime(BlackBoxExplainer):
             The perturbed samples corresponding to the masks applied to the original input
         """
         pert_samples = tf.expand_dims(original_input, axis=0)
-        pert_samples = tf.repeat(pert_samples, repeats=len(sample_masks), axis=0)
+        pert_samples = tf.repeat(pert_samples, repeats=sample_masks.shape[0], axis=0)
 
         # if there is channels we need to expand masks dimension
         if len(original_input.shape)==3:

--- a/xplique/attributions/occlusion.py
+++ b/xplique/attributions/occlusion.py
@@ -185,7 +185,7 @@ class Occlusion(BlackBoxExplainer):
             All the occluded combinations for each inputs.
         """
         occluded_inputs = tf.expand_dims(current_input, axis=0)
-        occluded_inputs = tf.repeat(occluded_inputs, repeats=len(masks), axis=0)
+        occluded_inputs = tf.repeat(occluded_inputs, repeats=masks.shape[0], axis=0)
 
         # check if current input shape is (W, H, C)
         has_channels = len(current_input.shape) > 2
@@ -222,7 +222,7 @@ class Occlusion(BlackBoxExplainer):
             Value reflecting the effect of each occlusion patchs on the output
         """
         baseline_scores = tf.expand_dims(baseline_scores, axis=-1)
-        occluded_scores = tf.reshape(occluded_scores, (-1, len(masks)))
+        occluded_scores = tf.reshape(occluded_scores, (-1, masks.shape[0]))
 
         score_delta = baseline_scores - occluded_scores
         # reshape the delta score to fit masks

--- a/xplique/attributions/rise.py
+++ b/xplique/attributions/rise.py
@@ -170,7 +170,7 @@ class Rise(BlackBoxExplainer):
         upsampled_masks = tf.image.resize(tf.cast(binary_masks, tf.float32),
                                           (upsampled_size, upsampled_size))
 
-        masks = tf.image.random_crop(upsampled_masks, (len(binary_masks),
+        masks = tf.image.random_crop(upsampled_masks, (binary_masks.shape[0],
                                                        *single_input.shape[:-1], 1))
 
         masked_input = tf.expand_dims(single_input, 0) * masks

--- a/xplique/attributions/smoothgrad.py
+++ b/xplique/attributions/smoothgrad.py
@@ -132,7 +132,7 @@ class SmoothGrad(WhiteBoxExplainer):
         noisy_inputs
             Duplicated inputs with noisy mask applied.
         """
-        nb_samples = len(noisy_mask)
+        nb_samples = noisy_mask.shape[0]
 
         noisy_inputs = tf.repeat(tf.expand_dims(inputs, axis=1), repeats=nb_samples, axis=1)
         noisy_inputs = noisy_inputs + noisy_mask


### PR DESCRIPTION
Replaced `len()` with `shape[0]` for several feature attribution methods (*lime*, *occlusion*, *rise* and *smoothgrad*) to fix error `len is not well-defined for symbolic tensors`