### PR TITLE
Plots: introduce single attribution plot

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -291,8 +291,6 @@ to enhance the library namely from [Justin PLAKOO](https://github.com/justinplak
 
 If you use Xplique as part of your workflow in a scientific publication, please consider citing the [Xplique official paper](https://arxiv.org/abs/2206.04394):
 
-If you use Xplique as part of your workflow in a scientific publication, please consider citing the 🗞️ [Xplique official paper](https://arxiv.org/abs/2206.04394):
-
 ```
 @article{fel2022xplique,
   title={Xplique: A Deep Learning Explainability Toolbox},


### PR DESCRIPTION
# Fix
apparently, in commit there was still a text duplicate in the doc, 088f3b67f2afb32be2fc66a1b69e739701445938 fix it.

# Plot
Current plot function only allow to plot multiple explanations. To allow more flexibility I proposed to split the current function into multiple sub functions to introduce a sub_function that allow to plot only one explanation.

Also, a simple wording issue but the `standardization` function was in fact doing a normalization. I propose to rename it.

This function is going to be useful for the next notebook on 'Sanity check'. :)

 