### PR TITLE
Attributions: introduce FORGrad 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ We propose some Hands-on tutorials to get familiar with the library and its api:
 
 - [**Attribution Methods**: Sanity checks paper](https://colab.research.google.com/drive/1uJOmAg6RjlOIJj6SWN9sYRamBdHAuyaS) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1uJOmAg6RjlOIJj6SWN9sYRamBdHAuyaS) </sub>
 - [**Attribution Methods**: Tabular data and Regression](https://colab.research.google.com/drive/1pjDJmAa9oeSquYtbYh6tksU6eTmObIcq) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1pjDJmAa9oeSquYtbYh6tksU6eTmObIcq) </sub>
+- [**FORGRad**: Gradient strikes back with FORGrad](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) </sub>
 - [**Attribution Methods**: Metrics](https://colab.research.google.com/drive/1WEpVpFSq-oL1Ejugr8Ojb3tcbqXIOPBg) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WEpVpFSq-oL1Ejugr8Ojb3tcbqXIOPBg) </sub>
 
 <p align="center" width="100%">
@@ -215,6 +216,7 @@ All the attributions method presented below handle both **Classification** and *
 | VarGrad                | TF            | [Paper](https://arxiv.org/abs/1810.03292) | ✔                  | ✔                 | WIP                | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/12-tlM_TdZ12oc5lNL2S2g-hcMJV8tZUD) |
 | Sobol Attribution      | TF            | [Paper](https://arxiv.org/abs/2111.04138) |                    | ✔                 |                    | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1XproaVxXjO9nrBSyyy7BuKJ1vy21iHs2) |
 | Hsic Attribution      | TF            | [Paper](https://arxiv.org/abs/2206.06219) |                    | ✔                 |                    | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1XproaVxXjO9nrBSyyy7BuKJ1vy21iHs2) |
+| FORGrad enhancement      | TF            | [Paper](https://arxiv.org/abs/2307.09591) |                    | ✔                 |                    | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) |
 
 
 * : See the [Callable documentation](https://deel-ai.github.io/xplique/callable/)

--- a/docs/api/attributions/forgrad.md
+++ b/docs/api/attributions/forgrad.md
@@ -1,0 +1,51 @@
+# FORGrad
+
+<sub>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/d/d0/Google_Colaboratory_SVG_Logo.svg" width="20">
+</sub> [View colab tutorial](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) |
+<sub>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" width="20">
+</sub> [View source](https://github.com/deel-ai/xplique/blob/master/xplique/attributions/forgrad.py) |
+📰 [Paper](https://arxiv.org/pdf/2307.09591.pdf)
+
+ForGrad is an enhancement for any attribution method by effectively filtering
+out high-frequency noise in gradient-based attribution maps, resulting in improved explainability scores and
+promoting the adoption of more computationally efficient techniques for model interpretability.
+
+!!! quote
+    The application of an optimal low-pass filter to attribution maps improves gradient-based attribution methods significantly, resulting in higher explainability scores across multiple models and elevating gradient-based methods to a top ranking among state-of-the-art techniques, sparking renewed interest in simpler and more computationally efficient explainability approaches.
+
+    -- <cite>[Gradient strikes back: How filtering out high frequencies improves explanations (2023)](https://arxiv.org/pdf/2307.09591.pdf)</cite>[^1]
+
+In a more precise manner, to obtain an attribution map $\varphi_\sigma(x)$, we apply a filter $w_\sigma$ with a cutoff value $\sigma$ to remove high frequencies, as shown in the equation:
+
+$$ \varphi_\sigma(x) = \mathcal{F}^{-1}((\mathcal{F} \cdot \varphi)(x) \odot w_\sigma) $$
+
+The parameter $\sigma$ controls the amount of frequencies retained and ranges between $(0, W]$, where $W$ represents the dimension of the squared image. A value of $0$ eliminates all frequencies, while $W$ retains all frequencies. The paper presents a method to estimate the optimal cutoff, and for ImageNet images, the recommended default value for the optimal sigma is typically around 15.
+
+
+## Example
+
+```python
+from xplique.attributions import Saliency
+from xplique.common import forgrad
+
+# load images, labels and model
+# ...
+
+method = Saliency(model)
+explanations = method.explain(images, labels)
+explanations_filtered = forgrad(explanations, sigma=15)
+```
+
+## Notebooks
+
+- [**FORGRad**: Gradient strikes back with FORGrad](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB)
+- [**Attribution Methods**: Getting started](https://colab.research.google.com/drive
+/1XproaVxXjO9nrBSyyy7BuKJ1vy21iHs2)
+
+
+{{xplique.attributions.forgrad.forgrad}}
+
+
+[^1]: [Gradient strikes back: How filtering out high frequencies improves explanations (2023)](https://arxiv.org/pdf/2307.09591.pdf)

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ We propose some Hands-on tutorials to get familiar with the library and its api:
 
 - [**Attribution Methods**: Sanity checks paper](https://colab.research.google.com/drive/1uJOmAg6RjlOIJj6SWN9sYRamBdHAuyaS) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1uJOmAg6RjlOIJj6SWN9sYRamBdHAuyaS) </sub>
 - [**Attribution Methods**: Tabular data and Regression](https://colab.research.google.com/drive/1pjDJmAa9oeSquYtbYh6tksU6eTmObIcq) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1pjDJmAa9oeSquYtbYh6tksU6eTmObIcq) </sub>
+- [**FORGRad**: Gradient strikes back with FORGrad](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) </sub>
 - [**Attribution Methods**: Metrics](https://colab.research.google.com/drive/1WEpVpFSq-oL1Ejugr8Ojb3tcbqXIOPBg) <sub> [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1WEpVpFSq-oL1Ejugr8Ojb3tcbqXIOPBg) </sub>
 
 <p align="center" width="100%">
@@ -216,6 +217,9 @@ All the attributions method presented below handle both **Classification** and *
 | VarGrad                | TF            | [Paper](https://arxiv.org/abs/1810.03292) | ✔                  | ✔                 | WIP                | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/12-tlM_TdZ12oc5lNL2S2g-hcMJV8tZUD) |
 | Sobol Attribution      | TF            | [Paper](https://arxiv.org/abs/2111.04138) |                    | ✔                 |                    | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1XproaVxXjO9nrBSyyy7BuKJ1vy21iHs2) |
 | Hsic Attribution      | TF            | [Paper](https://arxiv.org/abs/2206.06219) |                    | ✔                 |                    | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1XproaVxXjO9nrBSyyy7BuKJ1vy21iHs2) |
+| FORGrad enhancement      | TF            | [Paper](https://arxiv.org/abs/2307.09591) |                    | ✔                 |                    | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB) |
+
+
 
 
 * : See the [Callable documentation](https://deel-ai.github.io/xplique/callable/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Sobol Attribution Method: api/attributions/sobol.md
       - Hsic Attribution Method: api/attributions/hsic.md
       - VarGrad: api/attributions/vargrad.md
+      - ForGRad: api/attributions/forgrad.md
   - Concept based:
       - Cav: api/concepts/cav.md
       - Tcav: api/concepts/tcav.md

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="Xplique",
-    version="1.0.2",
+    version="1.0.3",
     description="Explanations toolbox for Tensorflow 2",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/attributions/test_forgrad.py
+++ b/tests/attributions/test_forgrad.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from xplique.commons import forgrad
+
+from ..utils import generate_data, generate_model
+from .test_common import _default_methods
+
+
+def test_base_forgrad():
+    """ Ensure forgrad is working with the expected shape """
+    shapes = [ (5, 32, 32, 3), (5, 32, 32, 1), (5, 32, 32), (5, 31, 31), (5, 60, 60) ]
+    sigmas = [5, 10, 30]
+
+    for shape in shapes:
+        heatmaps = np.random.rand(*shape).astype(np.float32)
+        for sigma in sigmas:
+            filtered_heatmaps = forgrad(heatmaps, sigma)
+            assert filtered_heatmaps.shape[:3] == heatmaps.shape[:3]
+
+
+def test_integration_forgrad():
+    """ Test that forgrad integrate with all attributions """
+    input_shape, nb_labels, samples = ((32, 32, 3), 10, 20)
+    model = generate_model(input_shape, nb_labels)
+    output_layer_index = -2
+
+    inputs_np, targets_np = generate_data(input_shape, nb_labels, samples)
+    methods = _default_methods(model, output_layer_index)
+
+    for method in methods:
+        explanations = method.explain(inputs_np, targets_np)
+        explanations_filtered = forgrad(explanations)
+
+        assert explanations_filtered.shape[:3] == explanations.shape[:3]
+
+

--- a/xplique/__init__.py
+++ b/xplique/__init__.py
@@ -6,7 +6,7 @@ The goal of Xplique is to provide a simple interface to the latest explanation
 techniques
 """
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 from . import attributions
 from . import concepts

--- a/xplique/commons/__init__.py
+++ b/xplique/commons/__init__.py
@@ -10,3 +10,4 @@ from .callable_operations import predictions_one_hot_callable
 from .operators import check_operator, operator_batching,\
                        get_inference_function, get_gradient_functions
 from .exceptions import no_gradients_available, raise_invalid_operator
+from .forgrad import forgrad

--- a/xplique/commons/forgrad.py
+++ b/xplique/commons/forgrad.py
@@ -1,0 +1,90 @@
+"""
+Module related to ForGrad method enchancement
+"""
+
+from functools import lru_cache
+
+import tensorflow as tf
+import numpy as np
+
+
+@lru_cache(maxsize=32)
+def _low_pass_real_signal_mask(size : int, bandwith : int) -> tf.Tensor:
+    """
+    Create a low pass filter mask to be applied on a real signal.
+    Since the Discrete Fourier Transform of a real signal is Hermitian-symmetric, only returns the
+    fft_length / 2 + 1 unique components of the transform.
+
+    Parameters
+    ----------
+    size
+        Size of the mask.
+    bandwith
+        Bandwith of the low pass filter. The higher the bandwith, the more frequencies are kept.
+
+    Returns
+    -------
+    mask
+        Low pass filter mask of shape (height, width).
+    """
+    center = (int(size/2), int(size/2))
+
+    y_grid, x_grid = np.ogrid[:size, :size]
+    dist_from_center = np.sqrt((x_grid - center[0])**2 + (y_grid-center[1])**2)
+
+    mask = dist_from_center <= bandwith
+    # un-center the mask
+    mask = tf.signal.fftshift(mask)
+    # keep only the unique components
+    mask = tf.cast(mask, tf.float32)[:, :size//2 + 1]
+
+    return mask
+
+def forgrad(explanations : tf.Tensor, sigma: int = 15) -> tf.Tensor:
+    """
+    ForGRAD is a method that enhances any attributions explanations (particularly useful on
+    gradients based attribution method) by eliminating high frequencies in the explanations.
+
+    Ref. Gradient strikes back: How filtering out high frequencies improves explanations (2023).
+         https://arxiv.org/pdf/2307.09591.pdf
+
+    Parameters
+    ----------
+    explanations
+        List of explanations to filter. Explanation should be at least 3D (batch, height, width)
+        and should have the same height and width.
+    sigma
+        Bandwith of the low pass filter. The higher the sigma, the more frequencies are kept.
+        Sigma should be positive and less than image size.
+        Default to paper recommendation, 15 for image size 224.
+
+    Returns
+    -------
+    filtered_explanations
+        Explanations low-pass filtered.
+    """
+    image_size = explanations.shape[1]
+
+    assert image_size == explanations.shape[2], "Explanations should be square."
+    assert len(explanations.shape) > 2, "Explanations should be at least 3D (batch, height, width)."
+    assert 0 < sigma <= image_size, "Sigma should be positive and less than image size."
+
+    if len(explanations.shape) == 4:
+        explanations = tf.reduce_mean(explanations, -1)
+    explanations = tf.abs(explanations)
+
+    spectrums = tf.signal.rfft2d(explanations)
+
+    filter_mask = _low_pass_real_signal_mask(explanations.shape[1], sigma)
+    filter_mask = tf.cast(filter_mask, tf.complex64)
+    filtered_spectrums = spectrums * filter_mask
+
+    filtered_explanations = tf.signal.irfft2d(filtered_spectrums)
+    filtered_explanations = tf.abs(filtered_explanations)
+
+    # resize if odd dimension (cut-off pixel)
+    if image_size % 2 == 1:
+        filtered_explanations = tf.image.resize(filtered_explanations[:, :, :, None],
+                                                (image_size, image_size), method="bicubic")
+
+    return filtered_explanations


### PR DESCRIPTION
### Gradient strikes back: How filtering out high frequencies improves explanations

This PR contains the implementation of FORGrad (paper here: https://arxiv.org/pdf/2307.09591.pdf). All in all, this method consists in filtering the noise in the explanations to make them more interpretable.

Basically, it use low-pass filter on the heatmaps after performing any of the attribution methods.
It therefore doesn’t require any major challenge, just a couple of functions will make the explanations look better.

### Core

Commit a7a0cb17bd7776590d121c06a3c98bb7a630ede9 contains the code with the implementation and the test. FORGrad is in the Attribution method but it is an attribution method enhancement. Otherwise, it has to be used in complement to a “standard” attribution method.

### Docs and utils

Commit 08f77478f47a4cabe792032983fa47f33b218fef provides the documentation and attach the notebook to the readme and documentation.

we (@S4b1n3, @fel-thomas) request the review from @lucashervier and @AntoninPoche.

Here is the notebook :) 
https://colab.research.google.com/drive/1ibLzn7r9QQIEmZxApObowzx8n9ukinYB#scrollTo=JJWlCx6LdXOH


Main author: @S4b1n3 🎉 
