### PR TITLE
Resolve issue #143 - all VRAM gets allocated when importing xplique

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 1.3.2
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="Xplique",
-    version="1.3.1",
+    version="1.3.2",
     description="Explanations toolbox for Tensorflow 2",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/wrappers/test_pytorch_wrapper.py
+++ b/tests/wrappers/test_pytorch_wrapper.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-import torch.nn as nn
 import tensorflow as tf
+import torch.nn as nn
 
 import pytest
 

--- a/xplique/__init__.py
+++ b/xplique/__init__.py
@@ -6,7 +6,7 @@ The goal of Xplique is to provide a simple interface to the latest explanation
 techniques
 """
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 from . import attributions
 from . import concepts

--- a/xplique/attributions/grad_cam_pp.py
+++ b/xplique/attributions/grad_cam_pp.py
@@ -42,7 +42,7 @@ class GradCAMPP(GradCAM):
 
     # Avoid zero division during procedure. (the value is not important, as if the denominator is
     # zero, then the nominator will also be zero).
-    EPSILON = tf.constant(1e-4)
+    EPSILON = 1e-4
 
     @staticmethod
     @tf.function

--- a/xplique/attributions/rise.py
+++ b/xplique/attributions/rise.py
@@ -44,7 +44,7 @@ class Rise(BlackBoxExplainer):
 
     # Avoid zero division during procedure. (the value is not important, as if the denominator is
     # zero, then the nominator will also be zero).
-    EPSILON = tf.constant(1e-4)
+    EPSILON = 1e-4
 
     def __init__(self,
                  model: Callable,

--- a/xplique/features_visualizations/preconditioning.py
+++ b/xplique/features_visualizations/preconditioning.py
@@ -33,7 +33,7 @@ def recorrelate_colors(images: tf.Tensor) -> tf.Tensor:
     images
         Images recorrelated.
     """
-    
+
     # constant
     imagenet_color_correlation = tf.cast(
       [[0.56282854, 0.58447580, 0.58447580],

--- a/xplique/features_visualizations/preconditioning.py
+++ b/xplique/features_visualizations/preconditioning.py
@@ -16,12 +16,6 @@ from ..types import Tuple, Union, Callable
 IMAGENET_SPECTRUM_URL = "https://storage.googleapis.com/serrelab/loupe/"\
                         "spectrums/imagenet_decorrelated.npy"
 
-imagenet_color_correlation = tf.cast(
-      [[0.56282854, 0.58447580, 0.58447580],
-       [0.19482528, 0.00000000,-0.19482528],
-       [0.04329450,-0.10823626, 0.06494176]], tf.float32
-)
-
 
 def recorrelate_colors(images: tf.Tensor) -> tf.Tensor:
     """
@@ -39,6 +33,14 @@ def recorrelate_colors(images: tf.Tensor) -> tf.Tensor:
     images
         Images recorrelated.
     """
+    
+    # constant
+    imagenet_color_correlation = tf.cast(
+      [[0.56282854, 0.58447580, 0.58447580],
+       [0.19482528, 0.00000000,-0.19482528],
+       [0.04329450,-0.10823626, 0.06494176]], tf.float32
+    )
+
     images_flat = tf.reshape(images, [-1, 3])
     images_flat = tf.matmul(images_flat, imagenet_color_correlation)
     return tf.reshape(images_flat, tf.shape(images))

--- a/xplique/utils_functions/object_detection.py
+++ b/xplique/utils_functions/object_detection.py
@@ -4,7 +4,7 @@ Operator for object detection
 from typing import Tuple
 import tensorflow as tf
 
-_EPSILON = tf.constant(1e-4)
+_EPSILON = 1e-4
 
 
 def _box_iou(boxes_a: tf.Tensor, boxes_b: tf.Tensor) -> tf.Tensor:

--- a/xplique/wrappers/pytorch.py
+++ b/xplique/wrappers/pytorch.py
@@ -25,9 +25,14 @@ class TorchWrapper(tf.keras.Model):
 
     def __init__(self, torch_model: "nn.Module", device: Union["torch.device", str],
                  is_channel_first: Optional[bool] = None
-                 ): # pylint: disable=C0415,C0103
+                 ): # pylint: disable=C0415,C0103,W0719
 
-        super().__init__()
+        try:
+            super().__init__()
+        except tf.errors.InternalError as error:
+            raise Exception("If you have a tensorflow InternalError with cudaGetDevice() here, \
+            it is possible that importing tensorflow before torch might resolve the issue."
+            ) from error
 
         try:
             # use PyTorch functionality


### PR DESCRIPTION
This PR tackles issue #143. The issue was due to global variables that were `tf.constant`. We change that and it removes the behavior. In the meantime, we noticed that importing `torch` before tensorflow while on GPU may cause errors. Consequently, we add a message if this error appears and change the import order in the test file for the PyTorch wrapper.