### PR TITLE
Fix docs deployment ci

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,7 @@ name: "Build and Publish Latest Release Docs"
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -21,7 +22,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: "Install Dependencies"
         run: |


### PR DESCRIPTION
CI broken because the python version was not set thus the job is not able to setup correctly. I also added the option to run docs jobs without the need for a new release.