### PR TITLE
Fix doc on v1.5.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,5 @@
 site_name: Xplique
 
-google_analytics:
-  - UA-132343476-2
-  - auto
 
 nav:
   - Home: index.md
@@ -116,6 +113,9 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 extra:
+  analytics:
+    provider: google
+    property: UA-132343476-2
   version:
     provider: mike
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy<2.0.0
-tensorflow>=2.1.0
-tensorflow-probability
+tensorflow>=2.1.0,<2.16.0
+tensorflow-probability<=0.23.0
 scikit-learn
 scikit-image
 matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.5.1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="Xplique",
-    version="1.5.0",
+    version="1.5.1",
     description="Explanations toolbox for Tensorflow 2",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/xplique/__init__.py
+++ b/xplique/__init__.py
@@ -6,7 +6,7 @@ The goal of Xplique is to provide a simple interface to the latest explanation
 techniques
 """
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 
 from . import attributions
 from . import commons

--- a/xplique/metrics/fidelity.py
+++ b/xplique/metrics/fidelity.py
@@ -520,15 +520,27 @@ class BaseAverageXMetric(ExplanationMetric, ABC):
 
     Parameters
     ----------
-    model, inputs, targets, batch_size, operator, activation
-        See `ExplanationMetric` base class.
+    model
+        Model used for computing metric.
+    inputs
+        Input samples under study.
+    targets
+        One-hot encoded labels or regression target (e.g {+1, -1}), one for each sample.
+    batch_size
+        Number of samples to process at once, if None compute all at once.
+    operator
+        Function g to explain. It should take 3 parameters (f, x, y) and return a scalar,
+        with f the model, x the inputs and y the targets. If None, use the standard
+        operator g(f, x, y) = f(x)[y].
+    activation
+        A string that belongs to [None, 'sigmoid', 'softmax']. Specify if we should add
+        an activation layer once the model has been called.
 
-    Returns (API)
-    -------------
-    evaluate(explanations) -> float
-        Mean metric over the dataset.
-    detailed_evaluate(explanations) -> np.ndarray
-        Vector of metric per-sample, shape (N,).
+    Notes
+    -----
+    Subclasses implement:
+    - `evaluate(explanations) -> float`
+    - `detailed_evaluate(inputs, targets, explanations) -> np.ndarray`
     """
     def __init__(self,
                  model: tf.keras.Model,
@@ -663,21 +675,33 @@ class AverageDropMetric(BaseAverageXMetric):
     - Builds M_i by |explanation|, channel-average (if 4D), per-sample min-max to [0,1],
       then broadcast to input shape, and multiplicatively masks inputs.
 
-    Ref. Chattopadhay, A., Sarkar, A., Howlader, P., & Balasubramanian, V. N. (2018, March).
+    References
+    ----------
+    Chattopadhay, A., Sarkar, A., Howlader, P., & Balasubramanian, V. N. (2018, March).
     Grad-cam++: Generalized gradient-based visual explanations for deep convolutional networks.
     In 2018 IEEE winter conference on applications of computer vision (WACV) (pp. 839-847). IEEE.
 
     Parameters
     ----------
-    model, inputs, targets, batch_size, operator, activation
-        See `ExplanationMetric` base class.
+    model
+        Model used for computing metric.
+    inputs
+        Input samples under study.
+    targets
+        One-hot encoded labels or regression target (e.g {+1, -1}), one for each sample.
+    batch_size
+        Number of samples to process at once, if None compute all at once.
+    operator
+        Function g to explain. It should take 3 parameters (f, x, y) and return a scalar,
+        with f the model, x the inputs and y the targets. If None, use the standard
+        operator g(f, x, y) = f(x)[y].
+    activation
+        A string that belongs to [None, 'sigmoid', 'softmax']. Specify if we should add
+        an activation layer once the model has been called.
 
-    Returns (API)
-    -------------
-    evaluate(explanations) -> float
-        Mean AD over the dataset.
-    detailed_evaluate(explanations) -> np.ndarray
-        Vector of AD per-sample, shape (N,).
+    Notes
+    -----
+    `evaluate(explanations)` returns the mean AD over the dataset.
     """
 
     def detailed_evaluate(
@@ -751,22 +775,32 @@ class AverageIncreaseMetric(BaseAverageXMetric):
     -----
     - Works best with probabilistic outputs; set `activation="softmax"` or `"sigmoid"`
       if your model returns logits.
+    - `evaluate(explanations)` returns the mean indicator over the dataset.
 
-    Ref. Chattopadhay, A., Sarkar, A., Howlader, P., & Balasubramanian, V. N. (2018, March).
+    References
+    ----------
+    Chattopadhay, A., Sarkar, A., Howlader, P., & Balasubramanian, V. N. (2018, March).
     Grad-cam++: Generalized gradient-based visual explanations for deep convolutional networks.
     In 2018 IEEE winter conference on applications of computer vision (WACV) (pp. 839-847). IEEE.
 
     Parameters
     ----------
-    model, inputs, targets, batch_size, operator, activation
-        See `ExplanationMetric`.
+    model
+        Model used for computing metric.
+    inputs
+        Input samples under study.
+    targets
+        One-hot encoded labels or regression target (e.g {+1, -1}), one for each sample.
+    batch_size
+        Number of samples to process at once, if None compute all at once.
+    operator
+        Function g to explain. It should take 3 parameters (f, x, y) and return a scalar,
+        with f the model, x the inputs and y the targets. If None, use the standard
+        operator g(f, x, y) = f(x)[y].
+    activation
+        A string that belongs to [None, 'sigmoid', 'softmax']. Specify if we should add
+        an activation layer once the model has been called.
 
-    Returns (API)
-    -------------
-    evaluate(explanations) -> float
-        Mean indicator over the dataset (i.e., percentage / 100).
-    detailed_evaluate(explanations) -> np.ndarray
-        Vector of binary indicators per-sample, shape (N,).
     """
 
     def detailed_evaluate(
@@ -839,22 +873,32 @@ class AverageGainMetric(BaseAverageXMetric):
     -----
     - Intended for scores in [0,1]. If your model outputs logits, use
       `activation="softmax"` / `"sigmoid"` at construction to operate on probabilities.
+    - `evaluate(explanations)` returns the mean AG over the dataset.
 
-    Parameters
+    References
     ----------
-    model, inputs, targets, batch_size, operator, activation
-        See `ExplanationMetric`.
-
-    Ref. Zhang, H., Torres, F., Sicre, R., Avrithis, Y., & Ayache, S. (2024).
+    Zhang, H., Torres, F., Sicre, R., Avrithis, Y., & Ayache, S. (2024).
     Opti-CAM: Optimizing saliency maps for interpretability.
     Computer Vision and Image Understanding, 248, 104101.
 
-    Returns (API)
-    -------------
-    evaluate(explanations) -> float
-        Mean AG over the dataset.
-    detailed_evaluate(explanations) -> np.ndarray
-        Vector of AG per-sample, shape (N,).
+    Parameters
+    ----------
+    model
+        Model used for computing metric.
+    inputs
+        Input samples under study.
+    targets
+        One-hot encoded labels or regression target (e.g {+1, -1}), one for each sample.
+    batch_size
+        Number of samples to process at once, if None compute all at once.
+    operator
+        Function g to explain. It should take 3 parameters (f, x, y) and return a scalar,
+        with f the model, x the inputs and y the targets. If None, use the standard
+        operator g(f, x, y) = f(x)[y].
+    activation
+        A string that belongs to [None, 'sigmoid', 'softmax']. Specify if we should add
+        an activation layer once the model has been called.
+
     """
 
     def detailed_evaluate(

--- a/xplique/metrics/randomization.py
+++ b/xplique/metrics/randomization.py
@@ -532,10 +532,9 @@ class RandomLogitMetric(BaseRandomizationMetric):
     seed
         Random seed used when sampling off-classes.
 
-    Returns (API)
-    -------------
-    evaluate(explainer) -> float
-        Mean SSIM over the dataset.
+    Notes
+    -----
+    `evaluate(explainer)` returns the mean SSIM over the dataset.
     """
     def __init__(self,
                  model: Callable,
@@ -645,8 +644,6 @@ class ModelRandomizationMetric(BaseRandomizationMetric):
     targets
         One-hot encoded labels, shape (N, C),
         or integer labels which will be one-hot encoded.
-    explainer
-        Attribution method implementing `explain(inputs, targets)`.
     randomization_strategy
         Strategy to randomize the model parameters. If None, a progressive
         randomization of top 25% layers is used.
@@ -657,10 +654,10 @@ class ModelRandomizationMetric(BaseRandomizationMetric):
     seed
         Random seed for reproducibility.
 
-    Returns (API)
-    -------------
-    evaluate(explainer) -> float
-        Mean Spearman correlation over the dataset.
+    Notes
+    -----
+    `evaluate(explainer)` returns the mean Spearman correlation over the dataset.
+    The `explainer` argument is passed to `evaluate`, not to `__init__`.
     """
 
     def __init__(self,


### PR DESCRIPTION
# Fix the documentation deployment on v1.5.0

Some errors in the docstring and unrestricted requirements made `mkdocs` fail during publishing the documentation. This PR fixes it so it now runs (at least, locally).