### PR TITLE
fix: attach tabular colorbar to plot axes

### DIFF
--- a/tests/plots/test_tabular_plots.py
+++ b/tests/plots/test_tabular_plots.py
@@ -1,0 +1,19 @@
+"""Tests for tabular plotting utilities."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from xplique.plots import summary_plot_tabular
+
+
+def test_summary_plot_tabular_adds_colorbar():
+    """The summary plot attaches its colorbar to the plot axes."""
+    explanations = np.array([[0.2, -0.1], [0.4, 0.3]])
+    features_values = np.array([[0.1, 0.8], [0.9, 0.2]])
+
+    summary_plot_tabular(explanations, features_values)
+
+    figure = plt.gcf()
+    assert len(figure.axes) == 2
+    assert [tick.get_text() for tick in figure.axes[1].get_yticklabels()] == ["Low", "High"]
+    plt.close(figure)

--- a/xplique/plots/tabular.py
+++ b/xplique/plots/tabular.py
@@ -42,9 +42,7 @@ def _select_features(explanations, max_display, features_name):
 
 
 def _add_colorbar(cmap, ax):
-    """
-    Add the color bar corresponding to cmap to the plot
-    """
+    """Add the color bar corresponding to `cmap` attached to the given Axes."""
     mappa = cm.ScalarMappable(cmap=cmap)
     colorbar = plt.colorbar(mappa, ax=ax, ticks=[0, 1])
     colorbar.set_ticklabels(["Low", "High"])

--- a/xplique/plots/tabular.py
+++ b/xplique/plots/tabular.py
@@ -41,12 +41,12 @@ def _select_features(explanations, max_display, features_name):
     return num_features_kept, features_idx_kept
 
 
-def _add_colorbar(cmap):
+def _add_colorbar(cmap, ax):
     """
     Add the color bar corresponding to cmap to the plot
     """
     mappa = cm.ScalarMappable(cmap=cmap)
-    colorbar = plt.colorbar(mappa, ticks=[0, 1])
+    colorbar = plt.colorbar(mappa, ax=ax, ticks=[0, 1])
     colorbar.set_ticklabels(["Low", "High"])
     colorbar.set_label("Feature value", size=12, labelpad=0)
     colorbar.ax.tick_params(labelsize=11, length=0)
@@ -350,7 +350,7 @@ def summary_plot_tabular(
 
     # draw the color bar
     if features_values is not None:
-        _add_colorbar(cmap)
+        _add_colorbar(cmap, plt.gca())
 
     # make the plot prettier
     plt.gca().xaxis.set_ticks_position("bottom")


### PR DESCRIPTION
## Description

Fixes #159.

`summary_plot_tabular` created a standalone `ScalarMappable` and passed it to `plt.colorbar()` without specifying the Axes from which the colorbar should take space. Recent Matplotlib versions therefore raise:

> ValueError: Unable to determine Axes to steal space for Colorbar.

This change passes the active tabular plot Axes explicitly to `plt.colorbar(..., ax=ax)`.

## Changes

* Update `_add_colorbar` to accept the target Axes.
* Attach the colorbar explicitly to the tabular summary plot.
* Add a regression test covering colorbar creation.

## Validation

* `MPLBACKEND=Agg pytest -q tests/plots/test_tabular_plots.py` — 1 passed
* `MPLBACKEND=Agg pytest -q tests/plots` — 16 passed
* `ruff check xplique/plots/tabular.py tests/plots/test_tabular_plots.py` — passed
* `ruff format --check xplique/plots/tabular.py tests/plots/test_tabular_plots.py` — passed
