### PR TITLE
Bump version: 2.0.0 → 2.0.1 + new regex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xplique"
-version = "2.0.0"
+version = "2.0.1"
 description = "Explanations toolbox for TensorFlow 2"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -92,15 +92,14 @@ include = ["xplique*"]
 "xplique.features_visualizations" = ["spectrum_decorrelated.npy"]
 
 [tool.bumpversion]
-current_version = "2.0.0"
+current_version = "2.0.1"
 commit = true
 tag = false
 
 [[tool.bumpversion.files]]
-filename = "pyproject.toml"
-
-[[tool.bumpversion.files]]
 filename = "xplique/__init__.py"
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'
 
 [tool.ruff]
 line-length = 100

--- a/xplique/__init__.py
+++ b/xplique/__init__.py
@@ -6,7 +6,7 @@ The goal of Xplique is to provide a simple interface to the latest explanation
 techniques
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 from . import attributions, commons, concepts, example_based, features_visualizations, plots
 from .commons import Tasks


### PR DESCRIPTION
Initially, I had the wrong order and tried to bump the version after the merge, which forced me to create a new PR.

However, through the PR, I discovered that the bump version was buggy: it searched for the version number and replaced its occurrences with the new version number. But this could also change dependency versions.

So I updated the regex and ran the bump version.